### PR TITLE
Remove unzip rule to extract only bin/*

### DIFF
--- a/protobuf/Dockerfile
+++ b/protobuf/Dockerfile
@@ -30,7 +30,7 @@ RUN apk add --update --no-cache -t deps wget ca-certificates \
     && echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf \
     # install protobuf
     && wget ${PROTOBUF_URL} \
-    && unzip ${PROTOBUF_ZIP} 'bin/*' -d /usr \
+    && unzip ${PROTOBUF_ZIP} -d /usr \
     # Cleanup
     && apk del --purge deps \
     && rm -rf /tmp/* /var/cache/apk/*


### PR DESCRIPTION
Allowing `include/*` to be extracted, we can use fields like [Any](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Any), [Timestamp](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp) and [Struct](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Struct) with its imports, for example:
```
import "google/protobuf/any.proto";
import "google/protobuf/timestamp.proto";
import "google/protobuf/struct.proto";
```